### PR TITLE
Remove the unnecessary Box in Handle and other changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coroutine"
-version = "0.1.5"
+version = "0.1.6"
 authors = [
     "Y. T. Chung <zonyitoo@gmail.com>",
     "Young.Wu <doomsplayer@gmail.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,14 +25,12 @@ enable-stack-recycle = []
 [build-dependencies]
 gcc = "*"
 log = "*"
-num_cpus = "*"
 
 [lib]
 name = "coroutine"
 path = "src/lib.rs"
 
 [dependencies]
-deque = "*"
 mmap = "*"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,14 @@ homepage = "https://github.com/rustcc/coroutine-rs"
 build = "build.rs"
 keywords = ["coroutine", "green", "thread", "fiber"]
 
+[features]
+
+default = [
+    "enable-stack-recycle"
+]
+
+enable-stack-recycle = []
+
 [build-dependencies]
 gcc = "*"
 log = "*"

--- a/src/context.rs
+++ b/src/context.rs
@@ -38,7 +38,7 @@ pub type InitFn = extern "C" fn(usize, *mut ()) -> !; // first argument is task 
 impl Context {
     pub fn empty() -> Context {
         Context {
-            regs: box Registers::new(),
+            regs: Box::new(Registers::new()),
             stack_bounds: None,
         }
     }
@@ -58,7 +58,7 @@ impl Context {
         let sp: *mut usize = sp as *mut usize;
         // Save and then immediately load the current context,
         // which we will then modify to call the given function when restored
-        let mut regs = box Registers::new();
+        let mut regs = Box::new(Registers::new());
 
         initialize_call_frame(&mut regs, init, arg, unsafe { transmute(Box::new(Thunk::new(start))) }, sp);
 

--- a/src/coroutine.rs
+++ b/src/coroutine.rs
@@ -82,7 +82,7 @@ use std::mem::transmute;
 use std::rt::unwind::try;
 use std::any::Any;
 use std::cell::UnsafeCell;
-use std::ops::{Deref, DerefMut};
+use std::ops::Deref;
 use std::ptr;
 use std::sync::Arc;
 use std::cell::RefCell;
@@ -138,24 +138,22 @@ impl Default for Options {
 
 /// Handle of a Coroutine
 #[derive(Debug, Clone)]
-pub struct Handle(Arc<RefCell<Box<Coroutine>>>);
+pub struct Handle(Arc<RefCell<Coroutine>>);
 
 unsafe impl Send for Handle {}
 unsafe impl Sync for Handle {}
 
 impl Handle {
-    fn new(c: Box<Coroutine>) -> Handle {
+    fn new(c: Coroutine) -> Handle {
         Handle(Arc::new(RefCell::new(c)))
     }
 
     unsafe fn get_inner_mut(&self) -> &mut Coroutine {
-        let c: &mut Box<Coroutine> = &mut *self.0.as_unsafe_cell().get();
-        c.deref_mut()
+        &mut *self.0.as_unsafe_cell().get()
     }
 
     unsafe fn get_inner(&self) -> &Coroutine {
-        let c: &Box<Coroutine> = &*self.0.as_unsafe_cell().get();
-        c.deref()
+        &*self.0.as_unsafe_cell().get()
     }
 
     /// Resume the Coroutine
@@ -319,7 +317,7 @@ extern "C" fn coroutine_initialize(_: usize, f: *mut ()) -> ! {
 
 impl Coroutine {
     unsafe fn empty(name: Option<String>, state: State) -> Handle {
-        Handle::new(box Coroutine {
+        Handle::new(Coroutine {
             current_stack_segment: None,
             saved_context: Context::empty(),
             parent: ptr::null_mut(),
@@ -329,7 +327,7 @@ impl Coroutine {
     }
 
     fn new(name: Option<String>, stack: Stack, ctx: Context, state: State) -> Handle {
-        Handle::new(box Coroutine {
+        Handle::new(Coroutine {
             current_stack_segment: Some(stack),
             saved_context: ctx,
             parent: ptr::null_mut(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico")]
 
-#![feature(box_syntax, std_misc, libc, asm, core, alloc, test, unboxed_closures, page_size)]
+#![feature(std_misc, libc, asm, core, alloc, test, unboxed_closures, page_size)]
 #![feature(rustc_private)]
 
 #[macro_use] extern crate log;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,6 @@
 #[macro_use] extern crate log;
 extern crate libc;
 extern crate test;
-extern crate deque;
 extern crate mmap;
 
 pub use coroutine::Builder;

--- a/src/thunk.rs
+++ b/src/thunk.rs
@@ -29,7 +29,7 @@ impl<'a, R> Thunk<'a,(),R> {
 impl<'a,A,R> Thunk<'a,A,R> {
     pub fn with_arg<F>(func: F) -> Thunk<'a,A,R> where F : FnOnce(A) -> R, F : Send + 'a {
         Thunk {
-            invoke: box func
+            invoke: Box::new(func)
         }
     }
 


### PR DESCRIPTION
1. Removed tailing spaces

2. `Deref` now can get the inner `Coroutine`

3. Removed all box syntax

4. Currently the `Handle` has `Arc`, so the `Box` is unnecessary

5. Bump version to 0.1.6