### PR TITLE
Remove usage of deprecated items. Fixes #52

### DIFF
--- a/examples/multithread.rs
+++ b/examples/multithread.rs
@@ -1,4 +1,3 @@
-#![feature(scoped)]
 extern crate coroutine;
 extern crate num_cpus;
 
@@ -11,7 +10,7 @@ fn main() {
     let mut threads = Vec::with_capacity(num_cpus::get());
 
     for i in 0..num_cpus::get() {
-        let t = thread::scoped(move|| {
+        let t = thread::spawn(move|| {
             spawn(move|| {
                 let thread_id = i;
                 spawn(move|| {
@@ -26,6 +25,6 @@ fn main() {
     }
 
     for t in threads.into_iter() {
-        t.join();
+        t.join().unwrap();
     }
 }

--- a/src/stack/stack_protected.rs
+++ b/src/stack/stack_protected.rs
@@ -31,7 +31,6 @@
 //  DEALINGS IN THE SOFTWARE.
 
 use std::ptr;
-use std::env::page_size;
 use std::fmt;
 
 use libc;
@@ -159,5 +158,21 @@ fn protect_last_page(stack: &MemoryMap) -> bool {
         libc::VirtualProtect(last_page, page_size() as libc::SIZE_T,
                              libc::PAGE_NOACCESS,
                              &mut old_prot as libc::LPDWORD) != 0
+    }
+}
+
+#[cfg(unix)]
+fn page_size() -> usize {
+    unsafe {
+        libc::sysconf(libc::_SC_PAGESIZE) as usize
+    }
+}
+
+#[cfg(windows)]
+fn page_size() -> usize {
+    unsafe {
+        let mut info = mem::zeroed();
+        libc::GetSystemInfo(&mut info);
+        info.dwPageSize as usize
     }
 }


### PR DESCRIPTION
Gets rid of usages of `thread::scoped` and `env::page_size` fixing the build on newest nightly.

Can't test on Windows machine, it would be nice to ensure this still works on that platform as well.