### PR TITLE
Implement std::error::Error for coroutine errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ pub enum Error {
 }
 
 impl Error {
-    fn description(&self) -> &str {
+    pub fn description(&self) -> &str {
         match *self {
             Error::Finished => "Finished",
             Error::Waiting => "Waiting",


### PR DESCRIPTION
This allows library users to handle coroutine errors with standard error composition techniques.

I'm a little unhappy with my implementation of the `cause` function- I would rather it return the underlying error for the `Panicking` variant. To make that change, I believe `Panicking` would need a value type of `Box<std::error::Error + Send>` instead of the current `Box<Any + Send>`, which would require some deeper function signature changes. I wanted to keep this PR small, but if there's interest in seeing the outcome of the function signature changes I'd be happy to put that together too.