### PR TITLE
Bugfix with std::mem (modern Rust)

### DIFF
--- a/src/stack/stack_protected.rs
+++ b/src/stack/stack_protected.rs
@@ -32,6 +32,7 @@
 
 use std::ptr;
 use std::fmt;
+use std::mem;
 
 use libc;
 


### PR DESCRIPTION
Can't compile in windows without std::mem import.

stack_protected.rs
```rust
#[cfg(windows)]
fn page_size() -> usize {
    unsafe {
        let mut info = mem::zeroed(); // this fails
        libc::GetSystemInfo(&mut info);
        info.dwPageSize as usize
    }
}
```