### PR TITLE
fix the c_void type check problem

### DIFF
--- a/src/asymmetric.rs
+++ b/src/asymmetric.rs
@@ -268,7 +268,9 @@ impl<T> Coroutine<T>
             }
         };
 
-        coro.context.init_with(coroutine_initialize, 0, Box::new(wrapper), &mut stack);
+        let callback: Box<FnBox()> = Box::new(wrapper);
+
+        coro.context.init_with(coroutine_initialize, 0, Box::into_raw(Box::new(callback)) as *mut libc::c_void, &mut stack);
         coro.stack = Some(stack);
 
         Coroutine {


### PR DESCRIPTION
Deal with [issue 59](https://github.com/rustcc/coroutine-rs/issues/59), `examples/simple.rs` is sound now