### PR TITLE
Use the version rather than the git repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Coroutine library in Rust
 
 ```toml
 [dependencies.coroutine]
-git = "https://github.com/rustcc/coroutine-rs.git"
+git = "0.5.0"
 ```
 
 ## Usage


### PR DESCRIPTION
There's no need for a full git URL when cargo can just get the version and download info from crates.io.