### PR TITLE
LocalSend instead of Send

### DIFF
--- a/examples/refcount.rs
+++ b/examples/refcount.rs
@@ -1,0 +1,27 @@
+extern crate coroutine;
+
+use std::rc::Rc;
+use std::cell::RefCell;
+use coroutine::asymmetric::Coroutine;
+
+fn main() {
+
+    let rc = Rc::new(RefCell::new(0));
+
+    let rc1 = rc.clone();
+    let mut coro1 = Coroutine::spawn(move |me| {
+        *rc1.borrow_mut() = 1;
+        let val = *rc1.borrow();
+        me.yield_with(val); // (*rc1.borrow()) - fails with already borrowed
+    });
+
+    let rc2 = rc.clone();
+    let mut coro2 = Coroutine::spawn(move |me| {
+        *rc2.borrow_mut() = 2;
+        let val = *rc2.borrow();
+        me.yield_with(val);
+    });
+
+    println!("First: {}", (*coro1).yield_with(0));
+    println!("Second: {}", (*coro2).yield_with(0));
+}

--- a/src/asymmetric.rs
+++ b/src/asymmetric.rs
@@ -123,19 +123,17 @@ pub struct Coroutine {
     state: State,
 }
 
-unsafe impl Send for Coroutine {}
-
 impl Coroutine {
     #[inline]
     pub fn spawn_opts<F>(f: F, opts: Options) -> Handle
-        where F: FnOnce(&mut Coroutine) + Send + 'static
+        where F: FnOnce(&mut Coroutine) + 'static
     {
         Self::spawn_opts_impl(Box::new(f), opts)
     }
 
     #[inline]
     pub fn spawn<F>(f: F) -> Handle
-        where F: FnOnce(&mut Coroutine) + Send + 'static
+        where F: FnOnce(&mut Coroutine) + 'static
     {
         Self::spawn_opts_impl(Box::new(f), Options::default())
     }
@@ -271,8 +269,6 @@ impl Handle {
         data
     }
 }
-
-unsafe impl Send for Handle {}
 
 impl Deref for Handle {
     type Target = Coroutine;


### PR DESCRIPTION
Proposal to fix #31 
With this PR I can compile `simple` example, but can't compile `tls` example:

```rust
extern crate coroutine;

use coroutine::asymmetric::Coroutine;
use std::cell::RefCell;

thread_local!(static LOCAL: RefCell<u32> = RefCell::new(7));

fn main() {
    let mut handle = Coroutine::spawn(move|cor| {
        LOCAL.with(|x| {
            *x.borrow_mut() += 1;
            let ptr: *const RefCell<u32> = x;
            println!("before: {:?} {:?} thread: {:?}", ptr, x, std::thread::current());
            cor.yield_with(0);
            let ptr: *const RefCell<u32> = x;
            println!("after: {:?} {:?} thread: {:?}", ptr, x, std::thread::current());
        });
    });

    (*handle).yield_with(0);

    std::thread::spawn(move || {
        (*handle).yield_with(0);
    }).join().unwrap();
}
```

Fails with:

```
   Compiling coroutine v0.5.0 (file:///home/denis/workspace/github.com/coroutine-rs)
examples/tls.rs:22:5: 22:23 error: the trait bound `*mut coroutine::asymmetric::Coroutine: std::marker::Send` is not satisfied [E0277]
examples/tls.rs:22     std::thread::spawn(move || {
                       ^~~~~~~~~~~~~~~~~~
examples/tls.rs:22:5: 22:23 help: run `rustc --explain E0277` to see a detailed explanation
examples/tls.rs:22:5: 22:23 note: `*mut coroutine::asymmetric::Coroutine` cannot be sent between threads safely
examples/tls.rs:22:5: 22:23 note: required because it appears within the type `coroutine::asymmetric::Handle`
examples/tls.rs:22:5: 22:23 note: required because it appears within the type `[closure@examples/tls.rs:22:24: 24:6 handle:coroutine::asymmetric::Handle]`
examples/tls.rs:22:5: 22:23 note: required by `std::thread::spawn`
error: aborting due to previous error
error: Could not compile `coroutine`.
```