### PR TITLE
Specify initial data

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ extern crate coroutine;
 use coroutine::asymmetric::Coroutine;
 
 fn main() {
-    let coro: Coroutine<i32> = Coroutine::spawn(|me| {
+    let coro: Coroutine<i32> = Coroutine::spawn(|me,_| {
         for num in 0..10 {
             me.yield_with(num);
         }

--- a/examples/refcount.rs
+++ b/examples/refcount.rs
@@ -9,14 +9,14 @@ fn main() {
     let rc = Rc::new(RefCell::new(0));
 
     let rc1 = rc.clone();
-    let mut coro1 = Coroutine::spawn(move |me| {
+    let mut coro1 = Coroutine::spawn(move |me,_| {
         *rc1.borrow_mut() = 1;
         let val = *rc1.borrow();
         me.yield_with(val); // (*rc1.borrow()) - fails with already borrowed
     });
 
     let rc2 = rc.clone();
-    let mut coro2 = Coroutine::spawn(move |me| {
+    let mut coro2 = Coroutine::spawn(move |me,_| {
         *rc2.borrow_mut() = 2;
         let val = *rc2.borrow();
         me.yield_with(val);

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -3,7 +3,7 @@ extern crate coroutine;
 use coroutine::asymmetric::Coroutine;
 
 fn main() {
-    let coro = Coroutine::spawn(|me| {
+    let coro = Coroutine::spawn(|me,_| {
         for num in 0..10 {
             me.yield_with(num);
         }


### PR DESCRIPTION
Initial data on fisrt resuming is unsound and lost. It's important to take any piece data of `resume` send.

This PR fixes it, and makes possible to take value of first `resume` call.

It breaks backward compatibility, but not terrible.

@zonyitoo What's your opinion?
