### PR TITLE
Explicit access to initial and final values of coroutine

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Basic usage of Coroutine
 ```rust
 extern crate coroutine;
 
+use std::usize;
 use coroutine::asymmetric::Coroutine;
 
 fn main() {
@@ -23,6 +24,7 @@ fn main() {
         for num in 0..10 {
             me.yield_with(num);
         }
+        usize::MAX
     });
 
     for num in coro {

--- a/examples/first_last.rs
+++ b/examples/first_last.rs
@@ -1,0 +1,12 @@
+extern crate coroutine;
+
+use coroutine::asymmetric::Coroutine;
+
+fn main() {
+    let mut coro = Coroutine::spawn(|_, initial| {
+        println!("Initial value: {}", initial);
+        2
+    });
+
+    println!("Final value: {}", coro.resume(1));
+}

--- a/examples/refcount.rs
+++ b/examples/refcount.rs
@@ -1,5 +1,6 @@
 extern crate coroutine;
 
+use std::usize;
 use std::rc::Rc;
 use std::cell::RefCell;
 use coroutine::asymmetric::Coroutine;
@@ -13,6 +14,7 @@ fn main() {
         *rc1.borrow_mut() = 1;
         let val = *rc1.borrow();
         me.yield_with(val); // (*rc1.borrow()) - fails with already borrowed
+        usize::MAX
     });
 
     let rc2 = rc.clone();
@@ -20,6 +22,7 @@ fn main() {
         *rc2.borrow_mut() = 2;
         let val = *rc2.borrow();
         me.yield_with(val);
+        usize::MAX
     });
 
     println!("First: {}", (*coro1).yield_with(0));

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,5 +1,6 @@
 extern crate coroutine;
 
+use std::usize;
 use coroutine::asymmetric::Coroutine;
 
 fn main() {
@@ -7,6 +8,7 @@ fn main() {
         for num in 0..10 {
             me.yield_with(num);
         }
+        usize::MAX
     });
 
     for num in coro {


### PR DESCRIPTION
PR #67 is great, but it has one imperfection: impossible to specify return value when coroutine ends (it return `usize::MAX` by default. I use library dinamically and take segfaults, because `resume` expects valid value anytime. We can solve it if closure will return value explicitly, but it makes API quite ugly and forces users to rewrite more code.

Another ides I tried:
* Check `usize::MAX` value, but I have to return additional data.
* If I will use explicit `yield` on tail, coroutine will contains invalid `is_finished` status.

I've made this PR to solve mentioned problems in better way. This PR takes profits:

1. Add possibility to get initial value of first `resume` call (by `get_first` method of `Coroutine`)
2. Add possibility to set final value when coroutine ends to last `resume` call (by `set_last` method of `Coroutine`)
3. Revert closure type to `FnOnce(&mut Coroutine)` to prevent user's code changing

It's more user-friendly, because API not changed and nobody have to change closures, but anyone can control first and last value explicitly.

@zonyitoo It needs your resoulition.
