### PR TITLE
Bump version to 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "coroutine"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
     "Y. T. Chung <zonyitoo@gmail.com>",
     "Young.Wu <doomsplayer@gmail.com>",
-    "Rustcc Developers"
+    "Rustcc Developers",
+    "Denis Kolodin <deniskolodin@gmail.com>"
 ]
 license = "MIT/ISC"
 repository = "https://github.com/rustcc/coroutine-rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico")]
 
-#![feature(fnbox, asm, test, unboxed_closures, std_panic, recover, panic_propagate)]
+#![feature(fnbox, asm, test, unboxed_closures)]
 
 #[macro_use] extern crate log;
 extern crate libc;


### PR DESCRIPTION
I've tested new features a lot and they are extremely reliable. I'm about:
* Initial value
* Last returning value
* Send marker absence

I made this PR to offer a new release of this library. The changes I've made:
* Bump version to **0.6.0** (because library has some backward-incompatible changes)
* Remove stabilized Rust features from unstable requirements (`std_panic`, `recover`, `panic_propagate`)
* Add myself as one of authors

```rust
src/lib.rs:15:48: 15:57 warning: this feature has been stable since 1.9.0. Attribute no longer needed, #[warn(stable_features)] on by default
src/lib.rs:15 #![feature(fnbox, asm, test, unboxed_closures, std_panic, recover, panic_propagate)]
                                                             ^~~~~~~~~
src/lib.rs:15:59: 15:66 warning: unused or unknown feature, #[warn(unused_features)] on by default
src/lib.rs:15 #![feature(fnbox, asm, test, unboxed_closures, std_panic, recover, panic_propagate)]
                                                                        ^~~~~~~
src/lib.rs:15:68: 15:83 warning: unused or unknown feature, #[warn(unused_features)] on by default
src/lib.rs:15 #![feature(fnbox, asm, test, unboxed_closures, std_panic, recover, panic_propagate)]
```

@zonyitoo Could you release a new one? If you don't agree with any change I'm ready to make it right.

P.S. I have a library I want to release which depends on this features.