### PR TITLE
Unhide docs for resume() and is_finished()

### DIFF
--- a/src/asymmetric.rs
+++ b/src/asymmetric.rs
@@ -231,14 +231,12 @@ impl Handle {
     }
 
     /// Check if the Coroutine is already finished
-    #[doc(hidden)]
     #[inline]
     pub fn is_finished(&self) -> bool {
         self.0 == ptr::null_mut()
     }
 
     /// Resume the Coroutine
-    #[doc(hidden)]
     #[inline]
     pub fn resume(&mut self, data: usize) -> usize {
         self.yield_with(State::Running, data)


### PR DESCRIPTION
I'm pretty sure that you didn't mean to hide these functions